### PR TITLE
Add missing dependencies for running the postprocess script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ or
 
     apt-get install -y fio
 
+and
+
+    pip install -r requirements.txt
+
 Obtain the maximum write bandwith and maximum read IOPS from the device data sheet.
 
 Run diskplorer (substitute `/dev/name` with your device file):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib


### PR DESCRIPTION
The postprocessing script requires `numpy` and `matplotlib`.
This PR adds a python requirements file containing these
dependencies and a README line on how to install the required packages.